### PR TITLE
feat: add AdonisJS v7 compatibility

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,1 @@
+package-lock = false

--- a/base_job.ts
+++ b/base_job.ts
@@ -1,145 +1,188 @@
-import app from "@adonisjs/core/services/app"
-import { ResqueConfig, ResqueFailure } from "./types.js"
-import { Plugin } from "node-resque"
+/*
+ * adonis-resque
+ *
+ * (c) Dai Jie <https://github.com/shiny>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+import app from "@adonisjs/core/services/app";
+import { type ResqueConfig, type ResqueFailure } from "./types.js";
+import { type Plugin } from "node-resque";
 
 export default class BaseJob {
+  interval?: string | number;
+  cron?: string;
 
-    interval?: string | number
-    cron?: string
+  plugins: [typeof Plugin, any][] = [];
 
-    plugins: [typeof Plugin, any][] = []
+  delayMs: number = 0;
+  runAtMs?: number;
+  /**
+   * the default JobName is this class name
+   * it **MUST be a unique name**
+   */
+  jobName?: string;
+  /**
+   * set a queueName for this job
+   * default configured in `config/resque.ts`
+   */
+  queueName?: string;
+  args: any[] = [];
+  allArgs: any[][] = [];
+  hasEnqueued: boolean = false;
+  hasEnqueuedAll: boolean = false;
+  app = app;
 
-    delayMs: number = 0
-    runAtMs?: number
-    /**
-     * the default JobName is this class name  
-     * it **MUST be a unique name**
-     */
-    jobName?: string
-    /**
-     * set a queueName for this job
-     * default configured in `config/resque.ts`
-     */
-    queueName?: string
-    args: any[] = []
-    allArgs: any[][] = []
-    hasEnqueued: boolean = false
-    hasEnqueuedAll: boolean = false
-    app = app
+  constructor(..._args: any[]) {}
 
-    constructor(..._args: any[]) {
+  queue(queueName: string) {
+    this.queueName = queueName;
+    return this;
+  }
 
-    }
-    queue(queueName: string) {
-        this.queueName = queueName
-        return this
-    }
-    static async enqueueAll<T extends typeof BaseJob>(this: T, args: Parameters<T['prototype']['perform']>[]) {
-        const job = await app.container.make(this)
-        return job.enqueueAll(args)
-    }
-    async enqueueAll<T extends BaseJob>(this: T, args: Parameters<T['perform']>[]) {
-        this.allArgs = args
-        this.hasEnqueuedAll = true
-        return this.execute()
-    }
-    perform(..._args: any[]): any {
+  static async enqueueAll<T extends typeof BaseJob>(
+    this: T,
+    args: Parameters<T["prototype"]["perform"]>[],
+  ) {
+    const job = await app.container.make(this);
+    return job.enqueueAll(args);
+  }
 
+  async enqueueAll<T extends BaseJob>(
+    this: T,
+    args: Parameters<T["perform"]>[],
+  ) {
+    this.allArgs = args;
+    this.hasEnqueuedAll = true;
+    return this.execute();
+  }
+
+  perform(..._args: any[]): any {}
+
+  handleError(error: unknown) {
+    throw error;
+  }
+
+  onFailure(_failure: ResqueFailure): void | Promise<void> {}
+
+  private async execute() {
+    const resqueConfig = app.config.get<ResqueConfig>("resque");
+    const jobName = this.jobName ?? this.constructor.name;
+    const queueName = this.queueName ?? resqueConfig.queueNameForJobs;
+    const queue = await app.container.make("queue");
+    let logger = await app.container.make("logger");
+    if (resqueConfig.logger) {
+      logger.use(resqueConfig.logger);
     }
-    handleError(error: unknown) {
-        throw error
-    }
-    onFailure(_failure: ResqueFailure): void | Promise<void> {}
-    private async execute() {
-        const resqueConfig = app.config.get<ResqueConfig>('resque')
-        const jobName = this.jobName ?? this.constructor.name
-        const queueName = this.queueName ?? resqueConfig.queueNameForJobs
-        const queue = await app.container.make('queue')
-        let logger = await app.container.make('logger')
-        if (resqueConfig.logger) {
-            logger.use(resqueConfig.logger)
+    if (this.hasEnqueued) {
+      const getTips = () => {
+        if (!resqueConfig.verbose) {
+          return undefined;
         }
-        if (this.hasEnqueued) {
-            const getTips = () => {
-                if (!resqueConfig.verbose) {
-                    return undefined
-                }
-                const tips = `enqueued to queue ${queueName}, job ${jobName}`
-                if (this.delayMs) {
-                    return `${tips}, delay ${this.delayMs}ms`
-                } else if (this.runAtMs) {
-                    return `${tips}, run at ${this.runAtMs}`
-                } else {
-                    return tips
-                }
-            }
-            const tips = getTips()
-            if (tips) {
-                logger.info(tips)
-            }
-            if (this.delayMs) {
-                return queue.enqueueIn(this.delayMs, queueName, jobName, this.args)
-            } else if (this.runAtMs) {
-                return queue.enqueueAt(this.runAtMs, queueName, jobName, this.args)
-            } else {
-                return queue.enqueue(queueName, jobName, this.args)
-            }
-        } else if (this.hasEnqueuedAll) {
-            return Promise.all(this.allArgs.map(arg => queue.enqueue(queueName, jobName, arg)))
+        const tips = `enqueued to queue ${queueName}, job ${jobName}`;
+        if (this.delayMs) {
+          return `${tips}, delay ${this.delayMs}ms`;
+        } else if (this.runAtMs) {
+          return `${tips}, run at ${this.runAtMs}`;
         } else {
-            return false
+          return tips;
         }
+      };
+      const tips = getTips();
+      if (tips) {
+        logger.info(tips);
+      }
+      if (this.delayMs) {
+        return queue.enqueueIn(this.delayMs, queueName, jobName, this.args);
+      } else if (this.runAtMs) {
+        return queue.enqueueAt(this.runAtMs, queueName, jobName, this.args);
+      } else {
+        return queue.enqueue(queueName, jobName, this.args);
+      }
+    } else if (this.hasEnqueuedAll) {
+      return Promise.all(
+        this.allArgs.map((arg) => queue.enqueue(queueName, jobName, arg)),
+      );
+    } else {
+      return false;
     }
+  }
 
+  private push<T extends BaseJob>({
+    args,
+    delayMs,
+    runAtMs,
+  }: {
+    args: Parameters<T["perform"]>;
+    delayMs?: number;
+    runAtMs?: number;
+  }) {
+    this.args = args;
+    this.hasEnqueued = true;
+    this.delayMs = delayMs ? delayMs : 0;
+    this.runAtMs = runAtMs;
+    return this.execute();
+  }
 
-    private push<T extends BaseJob>({ args, delayMs, runAtMs }: {
-        args: Parameters<T['perform']>;
-        delayMs?: number
-        runAtMs?: number
-    }) {
-        this.args = args
-        this.hasEnqueued = true
-        this.delayMs = delayMs ? delayMs : 0
-        this.runAtMs = runAtMs
-        return this.execute()
-    }
+  static async enqueue<T extends typeof BaseJob>(
+    this: T,
+    ...args: Parameters<InstanceType<T>["perform"]>
+  ) {
+    const job = await app.container.make(this);
+    return job.enqueue(...args);
+  }
 
-    static async enqueue<T extends typeof BaseJob>(this: T, ...args: Parameters<InstanceType<T>['perform']>) {
-        const job = await app.container.make(this)
-        return job.enqueue(...args)
-    }
-    async enqueue<T extends BaseJob>(this: T, ...args: Parameters<T['perform']>) {
-        return this.push({
-            args
-        })
-    }
+  async enqueue<T extends BaseJob>(this: T, ...args: Parameters<T["perform"]>) {
+    return this.push({
+      args,
+    });
+  }
 
-    /**
-     * 
-     * @param this 
-     * @param delayMs In ms, the number of ms to delay before this job is able to start being worked on
-     * @param args
-     * @returns 
-     */
-    static async enqueueIn<T extends typeof BaseJob>(this: T, delayMs: number, ...args: Parameters<InstanceType<T>['perform']>) {
-        const job = await app.container.make(this)
-        return job.enqueueIn(delayMs, ...args)
-    }
-    async enqueueIn<T extends BaseJob>(this: T, delayMs: number, ...args: Parameters<T['perform']>) {
-        return this.push({
-            args,
-            delayMs,
-        })
-    }
+  /**
+   * @param this
+   * @param delayMs In ms, the number of ms to delay before this job is able to start being worked on
+   * @param args
+   * @returns
+   */
+  static async enqueueIn<T extends typeof BaseJob>(
+    this: T,
+    delayMs: number,
+    ...args: Parameters<InstanceType<T>["perform"]>
+  ) {
+    const job = await app.container.make(this);
+    return job.enqueueIn(delayMs, ...args);
+  }
 
-    static async enqueueAt<T extends typeof BaseJob>(this: T, runAtMs: number, ...args: Parameters<InstanceType<T>['perform']>) {
-        const job = await app.container.make(this)
-        return job.enqueueAt(runAtMs, ...args)
-    }
-    async enqueueAt<T extends BaseJob>(this: T, runAtMs: number, ...args: Parameters<T['perform']>) {
-        return this.push({
-            args,
-            runAtMs,
-        })
-    }
+  async enqueueIn<T extends BaseJob>(
+    this: T,
+    delayMs: number,
+    ...args: Parameters<T["perform"]>
+  ) {
+    return this.push({
+      args,
+      delayMs,
+    });
+  }
+
+  static async enqueueAt<T extends typeof BaseJob>(
+    this: T,
+    runAtMs: number,
+    ...args: Parameters<InstanceType<T>["perform"]>
+  ) {
+    const job = await app.container.make(this);
+    return job.enqueueAt(runAtMs, ...args);
+  }
+
+  async enqueueAt<T extends BaseJob>(
+    this: T,
+    runAtMs: number,
+    ...args: Parameters<T["perform"]>
+  ) {
+    return this.push({
+      args,
+      runAtMs,
+    });
+  }
 }

--- a/base_plugin.ts
+++ b/base_plugin.ts
@@ -1,7 +1,19 @@
-import { Plugin } from "node-resque"
+/*
+ * adonis-resque
+ *
+ * (c) Dai Jie <https://github.com/shiny>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+import { Plugin } from "node-resque";
 
 export default abstract class BasePlugin extends Plugin {
-    static create<T extends typeof BasePlugin>(this: T, options: T['prototype']['options'] = {}): [T, T['prototype']['options']] {
-        return [this, options]
-    }
+  static create<T extends typeof BasePlugin>(
+    this: T,
+    options: T["prototype"]["options"] = {},
+  ): [T, T["prototype"]["options"]] {
+    return [this, options];
+  }
 }

--- a/commands/make_job.ts
+++ b/commands/make_job.ts
@@ -1,38 +1,49 @@
-import { BaseCommand, args } from '@adonisjs/core/ace'
-import type { CommandOptions } from '@adonisjs/core/types/ace'
-import { stubsRoot } from '../index.js'
+/*
+ * adonis-resque
+ *
+ * (c) Dai Jie <https://github.com/shiny>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
 
-import StringBuilder from '@poppinss/utils/string_builder'
+import { BaseCommand, args } from "@adonisjs/core/ace";
+import type { CommandOptions } from "@adonisjs/core/types/ace";
+import { stubsRoot } from "../index.js";
+
+import StringBuilder from "@poppinss/utils/string_builder";
 
 export default class MakeJob extends BaseCommand {
-    static commandName = 'make:job'
-    static description = 'Make a new job class'
+  static commandName = "make:job";
+  static description = "Make a new job class";
 
-    static options: CommandOptions = {
-        startApp: true,
-    }
+  static options: CommandOptions = {
+    startApp: true,
+  };
 
-    /**
-     * The name of the job file.
-     */
-    @args.string({ description: 'Name of the job file' })
-    declare name: string
+  /**
+   * The name of the job file.
+   */
+  @args.string({ description: "Name of the job file" })
+  declare name: string;
 
-
-    async run() {
-        const codemods = await this.createCodemods()
-        const jobName = new StringBuilder(this.name)
-            .removeExtension()
-            .removeSuffix('service')
-            .removeSuffix('model')
-            .singular()
-            .pascalCase()
-            .toString()
-        const jobFileName = new StringBuilder(jobName).snakeCase().ext('.ts').toString()
-        await codemods.makeUsingStub(stubsRoot, 'make/job/job.stub', {
-            flags: this.parsed.flags,
-            jobName,
-            jobFileName
-        })
-    }
+  async run() {
+    const codemods = await this.createCodemods();
+    const jobName = new StringBuilder(this.name)
+      .removeExtension()
+      .removeSuffix("service")
+      .removeSuffix("model")
+      .singular()
+      .pascalCase()
+      .toString();
+    const jobFileName = new StringBuilder(jobName)
+      .snakeCase()
+      .ext(".ts")
+      .toString();
+    await codemods.makeUsingStub(stubsRoot, "make/job/job.stub", {
+      flags: this.parsed.flags,
+      jobName,
+      jobFileName,
+    });
+  }
 }

--- a/commands/resque_start.ts
+++ b/commands/resque_start.ts
@@ -1,153 +1,213 @@
-import { BaseCommand, flags } from '@adonisjs/core/ace'
-import type { CommandOptions } from '@adonisjs/core/types/ace'
-import { createWorker, createMultiWorker, isMultiWorkerEnabled } from 'adonis-resque/services/main'
-import { importAllJobs } from '../jobs.js'
-import { cancelSchedules, createScheduler, Interval, startJobSchedules } from '../scheduler.js'
-import { MultiWorker, ParsedJob, Scheduler, Worker } from 'node-resque'
-import { getConfig } from '../index.js'
+/*
+ * adonis-resque
+ *
+ * (c) Dai Jie <https://github.com/shiny>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+import { BaseCommand, flags } from "@adonisjs/core/ace";
+import type { CommandOptions } from "@adonisjs/core/types/ace";
+import {
+  createWorker,
+  createMultiWorker,
+  isMultiWorkerEnabled,
+} from "adonis-resque/services/main";
+import { importAllJobs } from "../jobs.js";
+import {
+  cancelSchedules,
+  createScheduler,
+  type Interval,
+  startJobSchedules,
+} from "../scheduler.js";
+import {
+  type MultiWorker,
+  type ParsedJob,
+  type Scheduler,
+  type Worker,
+} from "node-resque";
+import { getConfig } from "../index.js";
 
 export default class ResqueStart extends BaseCommand {
-    static commandName = 'resque:start'
-    static description = 'Start workers / schedules for resque'
+  static commandName = "resque:start";
+  static description = "Start workers / schedules for resque";
 
-    static options: CommandOptions = {
-        startApp: true,
-        staysAlive: true,
+  static options: CommandOptions = {
+    startApp: true,
+    staysAlive: true,
+  };
+
+  @flags.boolean({
+    description: "start job schedule",
+  })
+  declare schedule: boolean;
+
+  @flags.boolean({
+    description: "start workers",
+    default: true,
+  })
+  declare worker: boolean;
+
+  @flags.boolean({
+    description: "multi workers",
+  })
+  declare isMulti: boolean;
+
+  @flags.boolean({
+    description: "enable log verbose",
+  })
+  declare verbose: boolean;
+
+  @flags.array({
+    description: "queue names for worker to listen",
+  })
+  declare queueName: string[];
+
+  intervals?: Interval[];
+  workerInstance?: MultiWorker | Worker;
+  schedulerInstance?: Scheduler;
+
+  async run() {
+    const pid = process.pid;
+    const jobs = await importAllJobs();
+    const emitter = await this.app.container.make("emitter");
+    const verbose = this.verbose ?? getConfig("verbose");
+
+    const inConsole = this.app.getEnvironment() === "console";
+    if (inConsole) {
+      const router = await this.app.container.make("router");
+      router.commit();
     }
-
-    @flags.boolean({
-        description: 'start job schedule'
-    })
-    declare schedule: boolean
-
-    @flags.boolean({
-        description: 'start workers',
-        default: true
-    })
-    declare worker: boolean
-
-    @flags.boolean({
-        description: 'multi workers'
-    })
-    declare isMulti: boolean
-
-    @flags.boolean({
-        description: 'enable log verbose'
-    })
-    declare verbose: boolean
-
-    @flags.array({
-        description: 'queue names for worker to listen'
-    })
-    declare queueName: string[]
-
-    intervals?: Interval[]
-    workerInstance?: MultiWorker | Worker
-    schedulerInstance?: Scheduler
-
-    async run() {
-        const pid = process.pid
-        const jobs = await importAllJobs()
-        const emitter = await this.app.container.make('emitter')
-        const verbose = this.verbose?? getConfig('verbose')
-
-        const inConsole = this.app.getEnvironment() === 'console'
-        if (inConsole) {
-            const router = await this.app.container.make('router')
-            router.commit()
-        }
-        if (this.worker) {
-            const queueNames =
-                this.queueName ?? getConfig('queueNameForWorkers')
-                    .split(',')
-                    .map((value) => value.trim())
-                    .filter((value) => value !== '')
-            const isMultiWorker = this.isMulti ?? isMultiWorkerEnabled()
-            if (isMultiWorker) {
-                this.workerInstance = createMultiWorker(jobs, queueNames) as MultiWorker
-                this.logger.info(`Resque multiWorker:${pid} started with ${Object.keys(jobs).length} jobs`)
-                this.workerInstance.on('failure', (workerId: number, queue: string, job: ParsedJob, failure: Error, duration: number) => {
-                    if (verbose)
-                        this.logger.info(`Job ${job.class} in queue ${queue} failed on worker ${workerId} in ${duration}ms`)
-                    emitter.emit('resque:failure', {
-                        workerId,
-                        queue,
-                        job: jobs[job.class],
-                        failure,
-                        duration,
-                        args: job.args,
-                        pluginOptions: job.pluginOptions
-                    })
-                })
-                this.workerInstance.on('cleaning_worker', (workerId: number, _worker: Worker, pid: number) => {
-                    if (verbose)
-                        this.logger.info(`Worker ${workerId} (PID ${pid}) cleaning up...`)
-                })
-                this.workerInstance.on('end', (workerId: number) => {
-                    if (verbose)
-                        this.logger.info(`Worker ${workerId} ended.`)
-                })
-                this.workerInstance.on('success', (workerId: number, queue: string, job: ParsedJob, result: any, duration: number) => {
-                    if (verbose)
-                        this.logger.success(`Job ${job.class} in queue ${queue} completed on worker ${workerId} in ${duration}ms, result: ${JSON.stringify(result)}`)
-                })
-
-            } else {
-                this.workerInstance = createWorker(jobs, queueNames)
-                this.workerInstance.on('failure', (queue: string, job: ParsedJob, failure: Error, duration: number) => {
-                    if (verbose)
-                        this.logger.info(`Job ${job.class} in queue ${queue} failed in ${duration}ms`)
-                    emitter.emit('resque:failure', {
-                        queue,
-                        job: jobs[job.class],
-                        failure,
-                        duration,
-                        args: job.args,
-                        pluginOptions: job.pluginOptions
-                    })
-                })
-                this.workerInstance.on('success', (queue: string, job: ParsedJob, result: any, duration: number) => {
-                    if (verbose)
-                        this.logger.success(`Job ${job.class} in queue ${queue} completed in ${duration}ms, result: ${JSON.stringify(result)}`)
-                })
-                await this.workerInstance.connect()
-            }
-            await this.workerInstance.start()
-
-        }
-        const runScheduler = getConfig('runScheduler')
-        if (this.schedule ?? runScheduler) {
-            this.schedulerInstance = createScheduler()
-            await this.schedulerInstance.connect()
-            await this.schedulerInstance.start()
-            this.schedulerInstance.on('end', () => {
-                if (verbose)
-                    this.logger.info(`Scheduler ended.`)
-            })
-            this.intervals = await startJobSchedules(this.schedulerInstance, jobs)
+    if (this.worker) {
+      const queueNames =
+        this.queueName ??
+        getConfig("queueNameForWorkers")
+          .split(",")
+          .map((value) => value.trim())
+          .filter((value) => value !== "");
+      const isMultiWorker = this.isMulti ?? isMultiWorkerEnabled();
+      if (isMultiWorker) {
+        this.workerInstance = createMultiWorker(
+          jobs,
+          queueNames,
+        ) as MultiWorker;
+        this.logger.info(
+          `Resque multiWorker:${pid} started with ${Object.keys(jobs).length} jobs`,
+        );
+        this.workerInstance.on(
+          "failure",
+          (
+            workerId: number,
+            queue: string,
+            job: ParsedJob,
+            failure: Error,
+            duration: number,
+          ) => {
             if (verbose)
-                this.logger.info(`Scheduler:${pid} started`)
-        }
+              this.logger.info(
+                `Job ${job.class} in queue ${queue} failed on worker ${workerId} in ${duration}ms`,
+              );
+            emitter.emit("resque:failure", {
+              workerId,
+              queue,
+              job: jobs[job.class],
+              failure,
+              duration,
+              args: job.args,
+              pluginOptions: job.pluginOptions,
+            });
+          },
+        );
+        this.workerInstance.on(
+          "cleaning_worker",
+          (workerId: number, _worker: Worker, workerPid: number) => {
+            if (verbose)
+              this.logger.info(
+                `Worker ${workerId} (PID ${workerPid}) cleaning up...`,
+              );
+          },
+        );
+        this.workerInstance.on("end", (workerId: number) => {
+          if (verbose) this.logger.info(`Worker ${workerId} ended.`);
+        });
+        this.workerInstance.on(
+          "success",
+          (
+            workerId: number,
+            queue: string,
+            job: ParsedJob,
+            result: any,
+            duration: number,
+          ) => {
+            if (verbose)
+              this.logger.success(
+                `Job ${job.class} in queue ${queue} completed on worker ${workerId} in ${duration}ms, result: ${JSON.stringify(result)}`,
+              );
+          },
+        );
+      } else {
+        this.workerInstance = createWorker(jobs, queueNames);
+        this.workerInstance.on(
+          "failure",
+          (queue: string, job: ParsedJob, failure: Error, duration: number) => {
+            if (verbose)
+              this.logger.info(
+                `Job ${job.class} in queue ${queue} failed in ${duration}ms`,
+              );
+            emitter.emit("resque:failure", {
+              queue,
+              job: jobs[job.class],
+              failure,
+              duration,
+              args: job.args,
+              pluginOptions: job.pluginOptions,
+            });
+          },
+        );
+        this.workerInstance.on(
+          "success",
+          (queue: string, job: ParsedJob, result: any, duration: number) => {
+            if (verbose)
+              this.logger.success(
+                `Job ${job.class} in queue ${queue} completed in ${duration}ms, result: ${JSON.stringify(result)}`,
+              );
+          },
+        );
+        await this.workerInstance.connect();
+      }
+      await this.workerInstance.start();
     }
+    const runScheduler = getConfig("runScheduler");
+    if (this.schedule ?? runScheduler) {
+      this.schedulerInstance = createScheduler();
+      await this.schedulerInstance.connect();
+      await this.schedulerInstance.start();
+      this.schedulerInstance.on("end", () => {
+        if (verbose) this.logger.info(`Scheduler ended.`);
+      });
+      this.intervals = await startJobSchedules(this.schedulerInstance, jobs);
+      if (verbose) this.logger.info(`Scheduler:${pid} started`);
+    }
+  }
 
-    prepare() {
-        const isVerbose = this.verbose ?? getConfig('verbose')
-        const terminate = async (signal: NodeJS.Signals) => {
-            if (isVerbose)
-                this.logger.info('Receive ' + signal)
-            await this.terminate()
-        }
-        const cleanup = async () => {
-            this.logger.info('Resque worker terminating...')
-            if (this.workerInstance) {
-                await this.workerInstance.end()
-            }
-            if (this.schedulerInstance) {
-                await this.schedulerInstance.end()
-            }
-            cancelSchedules(this.intervals)
-        }
-        this.app.listen('SIGINT', terminate).listen('SIGTERM', terminate)
-        this.app.terminating(cleanup)
-    }
+  prepare() {
+    const isVerbose = this.verbose ?? getConfig("verbose");
+    const terminate = async (signal: NodeJS.Signals) => {
+      if (isVerbose) this.logger.info("Receive " + signal);
+      await this.terminate();
+    };
+    const cleanup = async () => {
+      this.logger.info("Resque worker terminating...");
+      if (this.workerInstance) {
+        await this.workerInstance.end();
+      }
+      if (this.schedulerInstance) {
+        await this.schedulerInstance.end();
+      }
+      cancelSchedules(this.intervals);
+    };
+    this.app.listen("SIGINT", terminate).listen("SIGTERM", terminate);
+    this.app.terminating(cleanup);
+  }
 }

--- a/configure.ts
+++ b/configure.ts
@@ -1,52 +1,66 @@
-import type Configure from '@adonisjs/core/commands/configure'
-import { packageName, stubsRoot } from './index.js'
-import { access } from 'fs/promises'
+/*
+ * adonis-resque
+ *
+ * (c) Dai Jie <https://github.com/shiny>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+import type Configure from "@adonisjs/core/commands/configure";
+import { packageName, stubsRoot } from "./index.js";
+import { access } from "node:fs/promises";
+
 /**
  * Configures the package
  */
 export async function configure(command: Configure) {
-    const codemods = await command.createCodemods()
-    /**
-     * Check if @adonisjs/redis installed, or provide some suggestion.
-     */
-    if (await doesDependencyPackageMissing(command)) {
-        const dependencyPackage = '@adonisjs/redis'
-        const shouldInstallPackages = await command.prompt.confirm(
-            `Do you want to install dependencies ${dependencyPackage}?`,
-            { name: 'install', default: true }
-        )
-        const packagesToInstall = [
-            {
-                name: dependencyPackage,
-                isDevDependency: false
-            }
-        ]
-        if (shouldInstallPackages) {
-            await codemods.installPackages(packagesToInstall)
-            command.logger.warning(`Run ${command.colors.bgMagenta(command.colors.red(`node ace configure ${dependencyPackage}`))} after installing`)
-        } else {
-            await codemods.listPackagesToInstall(packagesToInstall)
-        }
-        command.logger.warning(`and configure ${command.colors.red(dependencyPackage)} correctly before using this package`)
-        command.logger.action
-    }
-    await codemods.makeUsingStub(stubsRoot, 'config/resque.stub', {})
+  const codemods = await command.createCodemods();
 
-    /**
-     * Register provider
-     */
-    await codemods.updateRcFile((rcFile) => {
-        rcFile.addProvider(`${packageName}/providers/resque_provider`)
-        rcFile.addCommand(`${packageName}/commands`)
-    })
+  /**
+   * Check if @adonisjs/redis installed, or provide some suggestion.
+   */
+  if (await doesDependencyPackageMissing(command)) {
+    const dependencyPackage = "@adonisjs/redis";
+    const shouldInstallPackages = await command.prompt.confirm(
+      `Do you want to install dependencies ${dependencyPackage}?`,
+      { name: "install", default: true },
+    );
+    const packagesToInstall = [
+      {
+        name: dependencyPackage,
+        isDevDependency: false,
+      },
+    ];
+    if (shouldInstallPackages) {
+      await codemods.installPackages(packagesToInstall);
+      command.logger.warning(
+        `Run ${command.colors.bgMagenta(command.colors.red(`node ace configure ${dependencyPackage}`))} after installing`,
+      );
+    } else {
+      await codemods.listPackagesToInstall(packagesToInstall);
+    }
+    command.logger.warning(
+      `and configure ${command.colors.red(dependencyPackage)} correctly before using this package`,
+    );
+  }
+  await codemods.makeUsingStub(stubsRoot, "config/resque.stub", {});
+
+  /**
+   * Register provider
+   */
+  await codemods.updateRcFile((rcFile) => {
+    rcFile.addProvider(`${packageName}/providers/resque_provider`);
+    rcFile.addCommand(`${packageName}/commands`);
+  });
 }
 
 async function doesDependencyPackageMissing(command: Configure) {
-    const redisConfigFile = command.app.configPath('redis.ts')
-    try {
-        await access(redisConfigFile)
-        return false
-    } catch (err: any) {
-        return true
-    }
+  const redisConfigFile = command.app.configPath("redis.ts");
+  try {
+    await access(redisConfigFile);
+    return false;
+  } catch {
+    return true;
+  }
 }

--- a/define_config.ts
+++ b/define_config.ts
@@ -1,17 +1,26 @@
-import type { RedisConnections } from './types.js'
-import { MultiWorker, Worker } from 'node-resque'
+/*
+ * adonis-resque
+ *
+ * (c) Dai Jie <https://github.com/shiny>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+import type { RedisConnections } from "./types.js";
+import { type MultiWorker, type Worker } from "node-resque";
 
 export function defineConfig<Connections extends RedisConnections>(config: {
-    redisConnection: keyof Connections
-    runWorkerInWebEnv: boolean
-    runScheduler: boolean
-    isMultiWorkerEnabled: boolean
-    multiWorkerOption: MultiWorker['options']
-    workerOption: Worker['options']
-    queueNameForJobs: string
-    queueNameForWorkers: string
-    logger: string | null
-    verbose: boolean
+  redisConnection: keyof Connections;
+  runWorkerInWebEnv: boolean;
+  runScheduler: boolean;
+  isMultiWorkerEnabled: boolean;
+  multiWorkerOption: MultiWorker["options"];
+  workerOption: Worker["options"];
+  queueNameForJobs: string;
+  queueNameForWorkers: string;
+  logger: string | null;
+  verbose: boolean;
 }) {
-    return config
+  return config;
 }

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -1,0 +1,3 @@
+import { configPkg } from '@adonisjs/eslint-config'
+
+export default configPkg()

--- a/index.ts
+++ b/index.ts
@@ -1,32 +1,47 @@
-export const packageName = 'adonis-resque'
+/*
+ * adonis-resque
+ *
+ * (c) Dai Jie <https://github.com/shiny>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
 
-export { configure } from './configure.js'
-export { defineConfig } from './define_config.js'
+export const packageName = "adonis-resque";
 
-export { Worker } from 'node-resque'
-export { Queue } from 'node-resque'
-export { default as BaseJob } from './base_job.js'
-export { default as BasePlugin } from './base_plugin.js'
-export { Plugin } from './plugin.js'
-export type { RetryOptions, JobLockOptions, NoopOptions, QueueLockOptions } from './plugin.js'
-import { joinToURL } from '@poppinss/utils'
-import { ResqueConfig } from './types.js'
-export * from './types.js'
-import app from '@adonisjs/core/services/app'
+export { configure } from "./configure.js";
+export { defineConfig } from "./define_config.js";
 
-export const stubsRoot = joinToURL(import.meta.url, 'stubs')
+export { Worker } from "node-resque";
+export { Queue } from "node-resque";
+export { default as BaseJob } from "./base_job.js";
+export { default as BasePlugin } from "./base_plugin.js";
+export { Plugin } from "./plugin.js";
+export type {
+  RetryOptions,
+  JobLockOptions,
+  NoopOptions,
+  QueueLockOptions,
+} from "./plugin.js";
+import { type ResqueConfig } from "./types.js";
+export * from "./types.js";
+import app from "@adonisjs/core/services/app";
+
+export const stubsRoot = import.meta.dirname + "/stubs";
 
 /**
- * Get a resque config 
+ * Get a resque config
  * @param name key name
  */
-export function getConfig<key extends keyof ResqueConfig>(name: key): ResqueConfig[key] {
-    return getConfigAll()[name]
+export function getConfig<Key extends keyof ResqueConfig>(
+  name: Key,
+): ResqueConfig[Key] {
+  return getConfigAll()[name];
 }
 
 /**
- * Get all resque config 
+ * Get all resque config
  */
 export function getConfigAll() {
-    return app.config.get<ResqueConfig>('resque')
+  return app.config.get<ResqueConfig>("resque");
 }

--- a/jobs.ts
+++ b/jobs.ts
@@ -1,54 +1,66 @@
-import app from "@adonisjs/core/services/app"
-import { fsImportAll } from "@poppinss/utils"
-import Job from "./base_job.js"
-import { NodeResqueJob } from './types.js'
+/*
+ * adonis-resque
+ *
+ * (c) Dai Jie <https://github.com/shiny>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+import app from "@adonisjs/core/services/app";
+import { fsImportAll } from "@poppinss/utils";
+import type Job from "./base_job.js";
+import { type NodeResqueJob } from "./types.js";
 
 export async function importAllJobs() {
-    const jobs: Record<string, unknown> = await fsImportAll(app.makePath('app/jobs'), {
-        ignoreMissingRoot: true
-    })
-    /**
-     * Duck typing check
-     * @param job 
-     * @returns 
-     */
-    const isValidJob = (job: any): job is typeof Job => {
-        if (!job) {
-            return false
-        }
-        if (typeof job?.prototype?.perform !=='function') {
-            return false
-        }
-        if (typeof job?.prototype?.enqueue !== 'function') {
-            return false
-        }
-        return true
+  const jobs: Record<string, unknown> = await fsImportAll(
+    app.makePath("app/jobs"),
+    {
+      ignoreMissingRoot: true,
+    },
+  );
+
+  const isValidJob = (job: any): job is typeof Job => {
+    if (!job) {
+      return false;
     }
-    const Jobs = Object.values(jobs).filter(isValidJob)
-    return Jobs.reduce(async (initlizedAccumulator, Job) => {
-        let accumulator = await initlizedAccumulator
-        const job = await app.container.make(Job)
-        if (!Array.isArray(job.plugins)) {
-            job.plugins = []
+    if (typeof job?.prototype?.perform !== "function") {
+      return false;
+    }
+    if (typeof job?.prototype?.enqueue !== "function") {
+      return false;
+    }
+    return true;
+  };
+
+  const Jobs = Object.values(jobs).filter(isValidJob);
+  return Jobs.reduce(async (initlizedAccumulator, Job) => {
+    let accumulator = await initlizedAccumulator;
+    const job = await app.container.make(Job);
+    if (!Array.isArray(job.plugins)) {
+      job.plugins = [];
+    }
+    const plugins = job.plugins.map(([plugin]) => plugin);
+    const pluginOptions = job.plugins.reduce(
+      (acc, [plugin, options]) => {
+        acc[plugin.name] = options;
+        return acc;
+      },
+      {} as Record<string, any>,
+    );
+    accumulator[Job.name] = {
+      perform: async (...args: any[]) => {
+        try {
+          const jobResult = await job.perform.call(job, ...args);
+          return jobResult;
+        } catch (error) {
+          return job.handleError.call(job, error);
         }
-        const plugins = job.plugins.map(([plugin]) => plugin)
-        const pluginOptions = job.plugins.reduce((acc, [plugin, options]) => {
-            acc[plugin.name] = options
-            return acc
-        }, {} as Record<string, any>)
-        accumulator[Job.name] = {
-            perform: async (...args: any[]) => {
-                try {
-                    const jobResult = await job.perform.call(job, ...args)
-                    return jobResult
-                } catch (error) {
-                    return job.handleError.call(job, error)
-                }
-            },
-            job,
-            plugins,
-            pluginOptions
-        }
-        return accumulator
-    }, Promise.resolve<Record<string, NodeResqueJob>>({}))
+      },
+      job,
+      plugins,
+      pluginOptions,
+    };
+    return accumulator;
+  }, Promise.resolve<Record<string, NodeResqueJob>>({}));
 }

--- a/package.json
+++ b/package.json
@@ -1,11 +1,16 @@
 {
   "name": "adonis-resque",
+  "description": "Resque Queue for AdonisJS",
   "version": "2.0.2",
   "type": "module",
-  "description": " Resque Queue for AdonisJS v6 ",
   "main": "build/index.js",
+  "engines": {
+    "node": ">=22.0.0"
+  },
   "files": [
-    "build"
+    "build",
+    "!build/bin",
+    "!build/tests"
   ],
   "exports": {
     ".": "./build/index.js",
@@ -14,29 +19,51 @@
     "./providers/resque_provider": "./build/providers/resque_provider.js",
     "./types": "./build/types.js"
   },
-  "engines": {
-    "node": ">=18.16.0"
-  },
   "scripts": {
-    "build": "npm run compile",
-    "dev": "tsup-node --watch --onSuccess 'tsc -d && npm run postcompile'",
-    "typecheck": "tsc --noEmit",
-    "copy:templates": "copyfiles \"stubs/**/**/*.stub\" build",
-    "compile": "tsup-node && tsc --emitDeclarationOnly --declaration",
+    "lint": "eslint",
+    "clean": "del-cli build",
+    "precompile": "npm run lint && npm run clean",
     "postcompile": "npm run copy:templates && npm run index:commands",
-    "test": "node --loader ts-node/esm --enable-source-maps bin/test.ts",
-    "index:commands": "adonis-kit index build/commands"
+    "compile": "tsup-node && tsc --emitDeclarationOnly --declaration",
+    "build": "npm run compile",
+    "copy:templates": "copyfiles \"stubs/**/**/*.stub\" build",
+    "index:commands": "adonis-kit index build/commands",
+    "quick:test": "node --enable-source-maps --import=@poppinss/ts-exec bin/test.ts",
+    "pretest": "npm run lint",
+    "test": "c8 npm run quick:test",
+    "typecheck": "tsc --noEmit",
+    "version": "npm run build",
+    "prepublishOnly": "npm run build"
   },
-  "bugs": {
-    "url": "https://github.com/shiny/adonis-resque/issues"
+  "devDependencies": {
+    "@adonisjs/assembler": "^8.0.0",
+    "@adonisjs/core": "^7.0.1",
+    "@adonisjs/eslint-config": "^3.0.0",
+    "@adonisjs/redis": "^9.1.0",
+    "@adonisjs/tsconfig": "^2.0.0",
+    "@japa/expect": "^3.0.2",
+    "@japa/expect-type": "^2.0.4",
+    "@japa/runner": "^5.3.0",
+    "@poppinss/ts-exec": "^1.4.4",
+    "@types/ms": "^0.7.34",
+    "@types/node": "^22.0.0",
+    "c8": "^11.0.0",
+    "copyfiles": "^2.4.1",
+    "del-cli": "^7.0.0",
+    "eslint": "^10.0.0",
+    "tsup": "^8.2.4",
+    "typescript": "^5.9.3"
   },
-  "keywords": [
-    "adonisjs",
-    "adonis6",
-    "resque",
-    "node-resque",
-    "queue"
-  ],
+  "dependencies": {
+    "@poppinss/utils": "^6.7.3",
+    "croner": "^8.1.1",
+    "ms": "^2.1.3",
+    "node-resque": "^9.3.5"
+  },
+  "peerDependencies": {
+    "@adonisjs/core": "^6.12.1 || ^7.0.0",
+    "@adonisjs/redis": "^8.0.0 || ^9.1.0"
+  },
   "author": "Chieh",
   "license": "MIT",
   "homepage": "https://github.com/shiny/adonis-resque",
@@ -44,36 +71,27 @@
     "type": "git",
     "url": "git+https://github.com/shiny/adonis-resque.git"
   },
-  "devDependencies": {
-    "@adonisjs/assembler": "^7.7.0",
-    "@adonisjs/core": "^6.12.1",
-    "@adonisjs/eslint-config": "^1.3.0",
-    "@adonisjs/prettier-config": "^1.3.0",
-    "@adonisjs/redis": "8.0.1",
-    "@adonisjs/tsconfig": "^1.3.0",
-    "@japa/expect": "3.0.2",
-    "@japa/expect-type": "2.0.2",
-    "@japa/runner": "3.1.4",
-    "@types/ms": "^0.7.34",
-    "@types/node": "^22.5.0",
-    "copyfiles": "^2.4.1",
-    "eslint": "^8.57.0",
-    "nock": "^13.5.5",
-    "ts-node": "^10.9.2",
-    "tsup": "^8.2.4",
-    "typescript": "^5.5.4"
+  "bugs": {
+    "url": "https://github.com/shiny/adonis-resque/issues"
   },
-  "peerDependencies": {
-    "@adonisjs/core": "^6.12.1",
-    "@adonisjs/redis": "^9.1.0"
-  },
+  "keywords": [
+    "adonisjs",
+    "adonisjs-v7",
+    "resque",
+    "node-resque",
+    "queue",
+    "worker",
+    "scheduler"
+  ],
   "tsup": {
     "entry": [
       "./index.ts",
       "./base_job.ts",
-      "commands/make_job.ts",
-      "commands/resque_start.ts",
-      "./src/types.ts",
+      "./base_plugin.ts",
+      "./define_config.ts",
+      "./types.ts",
+      "./commands/make_job.ts",
+      "./commands/resque_start.ts",
       "./services/main.ts",
       "./providers/resque_provider.ts"
     ],
@@ -83,11 +101,5 @@
     "dts": false,
     "sourcemap": true,
     "target": "esnext"
-  },
-  "dependencies": {
-    "@poppinss/utils": "^6.7.3",
-    "croner": "^8.1.1",
-    "ms": "^2.1.3",
-    "node-resque": "^9.3.5"
   }
 }

--- a/plugin.ts
+++ b/plugin.ts
@@ -1,101 +1,108 @@
-import { Plugins } from "node-resque"
-type LockKey = string | (() => string)
+/*
+ * adonis-resque
+ *
+ * (c) Dai Jie <https://github.com/shiny>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+import { Plugins } from "node-resque";
+
+type LockKey = string | (() => string);
+
 export interface JobLockOptions {
-    /**
-     * should we re-enqueue the job if it is already locked?
-     */
-    reEnqueue?: boolean
-    /**
-     * reEnqueue the job, delay it by <enqueueTimeout> milliseconds
-     */
-    enqueueTimeout?: number
-    /**
-     * lock the job for <lockTimeout> seconds
-     * default: 3600 (1 hour)
-     */
-    lockTimeout?: number
-    /**
-     * the key, for identifying the lock
-     */
-    key?: LockKey
+  /**
+   * should we re-enqueue the job if it is already locked?
+   */
+  reEnqueue?: boolean;
+  /**
+   * reEnqueue the job, delay it by <enqueueTimeout> milliseconds
+   */
+  enqueueTimeout?: number;
+  /**
+   * lock the job for <lockTimeout> seconds
+   * default: 3600 (1 hour)
+   */
+  lockTimeout?: number;
+  /**
+   * the key, for identifying the lock
+   */
+  key?: LockKey;
 }
+
 export interface NoopOptions {
-    logger?: (error: Error) => unknown
+  logger?: (error: Error) => unknown;
 }
+
 export interface QueueLockOptions {
-    /**
-     * in seconds
-     */
-    lockTimeout?: number
-    key?: LockKey
+  /**
+   * in seconds
+   */
+  lockTimeout?: number;
+  key?: LockKey;
 }
+
 export interface RetryOptions {
-    retryLimit?: number
-    /**
-     * in milliseconds, delay for next retry attempt.
-     */
-    retryDelay?: number
-    /**
-     * define an array containing the delay milliseconds number for each retry attempt.
-     * if the array is shorter than the retryLimit,
-     * the last value will be used for all remaining attempts.
-     */
-    backoffStrategy?: number[]
+  retryLimit?: number;
+  /**
+   * in milliseconds, delay for next retry attempt.
+   */
+  retryDelay?: number;
+  /**
+   * define an array containing the delay milliseconds number for each retry attempt.
+   * if the array is shorter than the retryLimit,
+   * the last value will be used for all remaining attempts.
+   */
+  backoffStrategy?: number[];
 }
+
 export class Plugin {
-    /**
-     * If a job with the same name, queue
-     * and args is already running
-     * put this job back in the queue and try later
-     * @param options.reEnqueue
-     * @param options.enqueueTimeout
-     * @param options.lockTimeout
-     * @param options.key
-     * If true, re-enqueue the job if it is already running. If false, do not enqueue the job if it is already running.
-     * @docs Source code: https://github.com/actionhero/node-resque/blob/main/src/plugins/JobLock.ts
-     */
-    static jobLock (options: JobLockOptions = {}): [typeof Plugins.JobLock, JobLockOptions] {
-        return [Plugins.JobLock, options]
-    }
-    /**
-     * If a job with the same name, queue
-     * and args is already in the delayed queue(s)
-     * do not enqueue it again
-     * @docs Source code: https://github.com/actionhero/node-resque/blob/main/src/plugins/DelayQueueLock.ts
-     */
-    static delayQueueLock(): [typeof Plugins.DelayQueueLock, {}]  {
-        return [Plugins.DelayQueueLock, {}]
-    }
-    /**
-     * Log the error and do not throw it
-     * @param options.logger
-     * @docs Source code: https://github.com/actionhero/node-resque/blob/main/src/plugins/Noop.ts
-     * A function to log the error.
-     */
-    static noop(options: NoopOptions = {}): [typeof Plugins.Noop, NoopOptions] {
-        return [Plugins.Noop, options]
-    }
-    /**
-     * If a job with the same name, queue
-     * and args is already in the queue
-     * do not enqueue it again
-     * @param options.lockTimeout
-     * @param options.key
-     * @docs Source Code: https://github.com/actionhero/node-resque/blob/main/src/plugins/QueueLock.ts
-     */
-    static queueLock(options: QueueLockOptions = {}): [typeof Plugins.QueueLock, QueueLockOptions] {
-        return [Plugins.QueueLock, options]
-    }
-    /**
-     * If a job fails, retry it N times 
-     * before finally placing it into the failed queue
-     * 
-     * @param options.retryLimit
-     * @param options.retryDelay
-     * @param options.backoffStrategy
-     * @docs Source code: https://github.com/actionhero/node-resque/blob/main/src/plugins/Retry.ts
-     */
-    static retry(options: RetryOptions = {}): [typeof Plugins.Retry, RetryOptions] {
-        return [Plugins.Retry, options]
-    }
+  /**
+   * If a job with the same name, queue
+   * and args is already running
+   * put this job back in the queue and try later
+   */
+  static jobLock(
+    options: JobLockOptions = {},
+  ): [typeof Plugins.JobLock, JobLockOptions] {
+    return [Plugins.JobLock, options];
+  }
+
+  /**
+   * If a job with the same name, queue
+   * and args is already in the delayed queue(s)
+   * do not enqueue it again
+   */
+  static delayQueueLock(): [typeof Plugins.DelayQueueLock, {}] {
+    return [Plugins.DelayQueueLock, {}];
+  }
+
+  /**
+   * Log the error and do not throw it
+   */
+  static noop(options: NoopOptions = {}): [typeof Plugins.Noop, NoopOptions] {
+    return [Plugins.Noop, options];
+  }
+
+  /**
+   * If a job with the same name, queue
+   * and args is already in the queue
+   * do not enqueue it again
+   */
+  static queueLock(
+    options: QueueLockOptions = {},
+  ): [typeof Plugins.QueueLock, QueueLockOptions] {
+    return [Plugins.QueueLock, options];
+  }
+
+  /**
+   * If a job fails, retry it N times
+   * before finally placing it into the failed queue
+   */
+  static retry(
+    options: RetryOptions = {},
+  ): [typeof Plugins.Retry, RetryOptions] {
+    return [Plugins.Retry, options];
+  }
 }

--- a/providers/resque_provider.ts
+++ b/providers/resque_provider.ts
@@ -1,56 +1,66 @@
-import { ApplicationService } from '@adonisjs/core/types'
-import { Queue } from '../types.js'
-import { importAllJobs } from '../jobs.js'
-import { BaseCommand } from '@adonisjs/core/ace'
-import { createQueue } from '../queue.js'
-import { getConfig } from '../index.js'
+/*
+ * adonis-resque
+ *
+ * (c) Dai Jie <https://github.com/shiny>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
 
-declare module '@adonisjs/core/types' {
-    interface ContainerBindings {
-      queue: Queue
-    }
+import { type ApplicationService } from "@adonisjs/core/types";
+import { type Queue } from "../types.js";
+import { importAllJobs } from "../jobs.js";
+import { type BaseCommand } from "@adonisjs/core/ace";
+import { createQueue } from "../queue.js";
+import { getConfig } from "../index.js";
+
+declare module "@adonisjs/core/types" {
+  interface ContainerBindings {
+    queue: Queue;
+  }
 }
 
 export default class ResqueProvider {
-    command?: BaseCommand
-    constructor(protected app: ApplicationService) {
-    }
+  command?: BaseCommand;
+  constructor(protected app: ApplicationService) {}
 
-    async register() {
-        this.app.container.singleton('queue', async () => {
-            const jobs = await importAllJobs()
-            const queue = createQueue(jobs)
-            await queue.connect()
-            return queue
-        })
-        const emitter = await this.app.container.make('emitter')
-        emitter.on('resque:failure', async failure => {
-            if (!failure?.job?.job) {
-                throw failure.failure
-            }
-            return failure.job.job.onFailure(failure)
-        })
-    }
+  async register() {
+    this.app.container.singleton("queue", async () => {
+      const jobs = await importAllJobs();
+      const queue = createQueue(jobs);
+      await queue.connect();
+      return queue;
+    });
+    const emitter = await this.app.container.make("emitter");
+    emitter.on("resque:failure", async (failure) => {
+      if (!failure?.job?.job) {
+        throw failure.failure;
+      }
+      return failure.job.job.onFailure(failure);
+    });
+  }
 
-    async start() {
-        if (this.app.getEnvironment() === 'web' && getConfig('runWorkerInWebEnv')) {
-            const ace = await this.app.container.make('ace')
-            await ace.boot()
-            if (ace.getCommand('resque:start')) {
-                this.command = await ace.exec('resque:start', [])
-                if (this.command.exitCode !== 0 || this.command.error) {
-                    const error = this.command.error || new Error(`Failed to start command resque:start`)
-                    throw error
-                }
-            }
+  async start() {
+    if (this.app.getEnvironment() === "web" && getConfig("runWorkerInWebEnv")) {
+      const ace = await this.app.container.make("ace");
+      await ace.boot();
+      if (ace.getCommand("resque:start")) {
+        this.command = await ace.exec("resque:start", []);
+        if (this.command.exitCode !== 0 || this.command.error) {
+          const error =
+            this.command.error ||
+            new Error("Failed to start command resque:start");
+          throw error;
         }
+      }
     }
+  }
 
-    async shutdown() {
-        if (this.command) {
-            await this.command.terminate()
-        }
-        const queue = await this.app.container.make('queue')
-        await queue.end()
+  async shutdown() {
+    if (this.command) {
+      await this.command.terminate();
     }
+    const queue = await this.app.container.make("queue");
+    await queue.end();
+  }
 }

--- a/queue.ts
+++ b/queue.ts
@@ -1,15 +1,20 @@
+/*
+ * adonis-resque
+ *
+ * (c) Dai Jie <https://github.com/shiny>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
 import { Queue } from "node-resque";
 import { getConnection } from "./services/main.js";
-import { NodeResqueJob } from "./types.js";
+import { type NodeResqueJob } from "./types.js";
 
 /**
  * Create a NodeResque Queue
  * @docs https://github.com/actionhero/node-resque?tab=readme-ov-file#queues
- * @param jobs 
- * @returns Queue
  */
 export function createQueue(jobs: Record<string, NodeResqueJob>) {
-    return new Queue({
-        connection: getConnection()
-    }, jobs);
+  return new Queue({ connection: getConnection() }, jobs);
 }

--- a/scheduler.ts
+++ b/scheduler.ts
@@ -1,89 +1,90 @@
-import { Scheduler } from 'node-resque'
-import { getConnection } from './services/main.js';
-import { NodeResqueJob } from './types.js';
-import Cron from 'croner'
-import ms from 'ms'
+/*
+ * adonis-resque
+ *
+ * (c) Dai Jie <https://github.com/shiny>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+import { Scheduler } from "node-resque";
+import { getConnection } from "./services/main.js";
+import { type NodeResqueJob } from "./types.js";
+import Cron from "croner";
+import ms from "ms";
 
 /**
  * Create a NodeResque Scheduler
  * @docs https://github.com/actionhero/node-resque?tab=readme-ov-file#scheduler
- * @returns 
  */
 export function createScheduler() {
-    return new Scheduler({
-        connection: getConnection(),
-    })
+  return new Scheduler({
+    connection: getConnection(),
+  });
 }
-export type Interval = NodeJS.Timeout | Cron
-export async function startJobSchedules(resqueScheduler: Scheduler, jobs: Record<string, NodeResqueJob>): Promise<Interval[]> {
-    const intervals: Interval[] = []
-    /**
-     * check whether is a leader sheduler or not
-     * @returns boolean isLeader
-     */
-    const isLeader = () => {
-        return resqueScheduler.leader
-    }
 
-    /**
-     * Create a croner if job.cron exists
-     * @param job 
-     * @returns 
-     */
-    const createCronerFor = (job: NodeResqueJob['job']) => {
-        if (job.cron) {
-            return Cron(job.cron, async () => {
-                if (isLeader()) {
-                    return await job.enqueue()
-                }
-            })
-        }
-    }
+export type Interval = NodeJS.Timeout | Cron;
 
-    /**
-     * let job repeat for every ${job.interval} 
-     * @param job 
-     * @returns 
-     */
-    const createRepeaterFor = (job: NodeResqueJob['job']) => {
-        if (!job.interval) {
-            return
+export async function startJobSchedules(
+  resqueScheduler: Scheduler,
+  jobs: Record<string, NodeResqueJob>,
+): Promise<Interval[]> {
+  const intervals: Interval[] = [];
+
+  const isLeader = () => {
+    return resqueScheduler.leader;
+  };
+
+  const createCronerFor = (job: NodeResqueJob["job"]) => {
+    if (job.cron) {
+      return Cron(job.cron, async () => {
+        if (isLeader()) {
+          return await job.enqueue();
         }
-        let milliseconds
-        if (typeof job.interval === 'number') {
-            milliseconds = job.interval
-        } else {
-            milliseconds = ms(job.interval)
-        }
-        const intervalId = setInterval(async () => {
-            if (isLeader()) {
-                await job.enqueue()
-            }
-        }, milliseconds)
-        return intervalId
+      });
     }
-    for (const { job } of Object.values(jobs)) {
-        const croner = createCronerFor(job)
-        if (croner) {
-            intervals.push(croner)
-        }
-        const intervalId = createRepeaterFor(job)
-        if (intervalId) {
-            intervals.push(intervalId)
-        }
+  };
+
+  const createRepeaterFor = (job: NodeResqueJob["job"]) => {
+    if (!job.interval) {
+      return;
     }
-    return intervals
+    let milliseconds;
+    if (typeof job.interval === "number") {
+      milliseconds = job.interval;
+    } else {
+      milliseconds = ms(job.interval);
+    }
+    const intervalId = setInterval(async () => {
+      if (isLeader()) {
+        await job.enqueue();
+      }
+    }, milliseconds);
+    return intervalId;
+  };
+
+  for (const { job } of Object.values(jobs)) {
+    const croner = createCronerFor(job);
+    if (croner) {
+      intervals.push(croner);
+    }
+    const intervalId = createRepeaterFor(job);
+    if (intervalId) {
+      intervals.push(intervalId);
+    }
+  }
+  return intervals;
 }
 
 export function cancelSchedules(intervals?: Interval[]) {
-    if (!intervals) {
-        return
+  if (!intervals) {
+    return;
+  }
+  for (const interval of intervals) {
+    if (interval instanceof Cron) {
+      interval.stop();
+    } else {
+      clearInterval(interval);
     }
-    for(const inteval of intervals) {
-        if (inteval instanceof Cron) {
-            inteval.stop()
-        } else {
-            clearInterval(inteval)
-        }
-    }
+  }
 }

--- a/services/main.ts
+++ b/services/main.ts
@@ -1,39 +1,57 @@
-import app from "@adonisjs/core/services/app"
-import { Jobs, MultiWorker, Worker } from "node-resque"
-import { RedisConnections } from '@adonisjs/redis/types'
-import { defineConfig } from "../define_config.js"
+/*
+ * adonis-resque
+ *
+ * (c) Dai Jie <https://github.com/shiny>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+import app from "@adonisjs/core/services/app";
+import { type Jobs, MultiWorker, Worker } from "node-resque";
+import { type RedisConnections } from "@adonisjs/redis/types";
+import { type defineConfig } from "../define_config.js";
 
 export function getConnection() {
-    const resqueConfig = app.config.get<ReturnType<typeof defineConfig>>('resque')
-    const connections = app.config.get<RedisConnections>('redis.connections')
-    const connection = connections[resqueConfig.redisConnection] as any
-    return {
-        host: connection.host,
-        port: Number.parseInt(connection.port ?? '6379'),
-        options: connection,
-        pkg: 'ioredis',
-        database: connection.db ?? 0,
-    }
+  const resqueConfig =
+    app.config.get<ReturnType<typeof defineConfig>>("resque");
+  const connections = app.config.get<RedisConnections>("redis.connections");
+  const connection = connections[resqueConfig.redisConnection] as any;
+  return {
+    host: connection.host,
+    port: Number.parseInt(connection.port ?? "6379"),
+    options: connection,
+    pkg: "ioredis",
+    database: connection.db ?? 0,
+  };
 }
 
 export function createWorker(jobs: Jobs, queues: string[]) {
-    const workerOption = app.config.get<Worker['options']>('resque.workerOption')
-    return new Worker({
-        connection: getConnection(),
-        queues,
-        ...workerOption
-    }, jobs)
+  const workerOption = app.config.get<Worker["options"]>("resque.workerOption");
+  return new Worker(
+    {
+      connection: getConnection(),
+      queues,
+      ...workerOption,
+    },
+    jobs,
+  );
 }
 
 export function createMultiWorker(jobs: Jobs, queues: string[]) {
-    const multiWorkerOption = app.config.get<MultiWorker['options']>('resque.multiWorkerOption')
-    return new MultiWorker({
-        queues,
-        connection: getConnection(),
-        ...multiWorkerOption,
-    }, jobs)
+  const multiWorkerOption = app.config.get<MultiWorker["options"]>(
+    "resque.multiWorkerOption",
+  );
+  return new MultiWorker(
+    {
+      queues,
+      connection: getConnection(),
+      ...multiWorkerOption,
+    },
+    jobs,
+  );
 }
 
 export function isMultiWorkerEnabled() {
-    return app.config.get<boolean>('resque.isMultiWorkerEnabled')
+  return app.config.get<boolean>("resque.isMultiWorkerEnabled");
 }

--- a/types.ts
+++ b/types.ts
@@ -1,34 +1,42 @@
-export { Worker, Plugins, Scheduler, Queue } from "node-resque"
-export type { RedisConnections } from '@adonisjs/redis/types'
-import { Plugin } from "node-resque"
-import BaseJob from "./base_job.js"
-import { defineConfig } from "./define_config.js"
-export type ResqueConfig = ReturnType<typeof defineConfig>
+/*
+ * adonis-resque
+ *
+ * (c) Dai Jie <https://github.com/shiny>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+export { Worker, Plugins, Scheduler, Queue } from "node-resque";
+export type { RedisConnections } from "@adonisjs/redis/types";
+import { type Plugin } from "node-resque";
+import type BaseJob from "./base_job.js";
+import { type defineConfig } from "./define_config.js";
+export type ResqueConfig = ReturnType<typeof defineConfig>;
 
 export interface NodeResqueJob {
-    perform(..._args: any[]): any
-    job: BaseJob
-    plugins: typeof Plugin[],
-    pluginOptions: Record<string, any>
-    args?: any[]
+  perform(..._args: any[]): any;
+  job: BaseJob;
+  plugins: (typeof Plugin)[];
+  pluginOptions: Record<string, any>;
+  args?: any[];
 }
 export interface JobSchedule {
-    interval?: string | number
-    cron?: string
+  interval?: string | number;
+  cron?: string;
 }
 
 export interface ResqueFailure {
-    workerId?: number
-    queue: string
-    job: NodeResqueJob
-    failure: Error
-    duration: number
-    args: any[]
-    pluginOptions?: Record<string, any>
+  workerId?: number;
+  queue: string;
+  job: NodeResqueJob;
+  failure: Error;
+  duration: number;
+  args: any[];
+  pluginOptions?: Record<string, any>;
 }
-declare module '@adonisjs/core/types' {
-    interface EventsList {
-        'resque:failure': ResqueFailure
-    }
+declare module "@adonisjs/core/types" {
+  interface EventsList {
+    "resque:failure": ResqueFailure;
+  }
 }
-  


### PR DESCRIPTION
I've been using this package in production and needed AdonisJS v7 support, so I've done the migration work.

## Changes

- Update peerDependencies to support both `@adonisjs/core ^6 || ^7` and `@adonisjs/redis ^8 || ^9`
- Update all devDependencies to latest versions (Japa 5, ESLint 10, TypeScript 5.9)
- Replace `ts-node` with `@poppinss/ts-exec` for test runner
- Migrate to ESLint flat config
- Add copyright headers to all source files
- Reformat codebase with consistent style
- Update tsup entry points to include all exported modules
- Bump minimum Node version to 22 (aligned with AdonisJS v7)

If you're still actively maintaining this package, I'd love to see this merged. Otherwise, I'm happy to continue maintaining a fork under `@dirupt/adonis-resque` (already published on npm).